### PR TITLE
Add various ReadTheDocs improvements

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -37,7 +37,19 @@ templates_path = ['_templates']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'venv', 'internal', 'README.md', 'dev-manuals/README.md', 'adr/README.md', 'adr/adr-template.md', 'template-README.md', 'user-manuals/README.md', '**/template*.md', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ['_build',
+        'venv',
+        'internal',
+        'README.md',
+        'dev-manuals/README.md',
+        'adr/README.md',
+        'install-manuals/README.md',
+        'adr/adr-template.md',
+        'template-README.md',
+        'user-manuals/README.md',
+        '**/template*.md',
+        'Thumbs.db',
+        '.DS_Store']
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -51,3 +63,13 @@ html_theme = 'alabaster'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = []
+
+# Generate HTML anchors (test#h1-title) for titles up to h4
+myst_heading_anchors = 4
+
+myst_enable_extensions = [
+        'colon_fence', # :::$TYPE\n$CONTENT\n::: == ```$TYPE\n$CONTENT\n```
+        'html_admonition', # :::{attention, caution, danger, error, hint, important, note, tip, warning} $TITLE\n$CONTENT\n::: -> renders a message with the given title and content in the given style
+        'linkify', # www.google.com -> <www.google.com>
+        'tasklist', # [ ] -> unchecked checkbox, [x] -> checked checkbox
+        ]

--- a/dev-manuals/etc/glossary.md
+++ b/dev-manuals/etc/glossary.md
@@ -11,17 +11,11 @@ Imagine the phrase: `A xy is ...` when writing an explanation.
 
 [A](#a) [B](#b) [C](#c) [D](#d) [E](#e) [F](#f) [G](#g) [H](#h) [I](#i) [J](#j) [K](#k) [L](#l) [M](#m) [N](#n) [O](#o) [P](#p) [Q](#q) [R](#r) [S](#s) [T](#t) [U](#u) [V](#v) [W](#w) [X](#x) [Y](#y) [Z](#z)
 
-(#a)=
-
 ## A
-
-(#area)=
 
 ### Area
 
 - a part of the gamefield where the player can move, abstract class for [World](#world) and [Dungeon](#dungeon)
-
-(#asset)=
 
 ### Asset
 
@@ -31,19 +25,12 @@ Imagine the phrase: `A xy is ...` when writing an explanation.
 
 - a downloadable file containing [assets](#asset) e.g. in the [Unity](#unity) [asset store](https://assetstore.unity.com/)
 
-(#b)=
-
 ## B
-
-(#c)=
 
 ## C
 
-(#d)=
 
 ## D
-
-(#dungeon)=
 
 ### Dungeon
 
@@ -52,19 +39,11 @@ Imagine the phrase: `A xy is ...` when writing an explanation.
 - See the concept [here](/protocols/global/2022-06-03-protocol-1.md)
   - squares are the entrances to a dungeon
 
-(#e)=
-
 ## E
-
-(#f)=
 
 ## F
 
-(#g)=
-
 ## G
-
-(#h)=
 
 ## H
 
@@ -72,27 +51,17 @@ Imagine the phrase: `A xy is ...` when writing an explanation.
 
 - The HUD (head-up display) is frequently used to simultaneously display several pieces of information including the main character's health, items, and an indication of game progression
 
-(#i)=
-
 ## I
 
 ### Issue
 
 - Representation of a Task on GitHub
 
-(#j)=
-
 ## J
-
-(#k)=
 
 ## K
 
-(#l)=
-
 ## L
-
-(#level)=
 
 ### Level
 
@@ -102,11 +71,7 @@ Imagine the phrase: `A xy is ...` when writing an explanation.
 - See the concept [here](/protocols/global/2022-06-03-protocol-1.md)
   - 2, 3, 4, ... on the left side of the picture are levels
 
-(#m)=
-
 ## M
-
-(#minigame)=
 
 ### Minigame
 
@@ -116,31 +81,19 @@ Imagine the phrase: `A xy is ...` when writing an explanation.
 
 - we don't do this here
 
-(#n)=
-
 ## N
-
-(#npc)=
 
 ### NPC
 
 - a non player character which can be interacted with. These characters can appear in the overworld, in dungeons or in games.
 
-(#o)=
-
 ## O
-
-(#overworld)=
 
 ### Overworld
 
 - the first world the player will see after starting the game. Here he can explore the world and start [minigames](#minigame).
 
-(#p)=
-
 ## P
-
-(#q)=
 
 ## Q
 
@@ -149,29 +102,19 @@ Imagine the phrase: `A xy is ...` when writing an explanation.
 - describes how easy a user can use a service
 - does not regard whether the actual functionality exists 
 
-(#r)=
-
 ## R
 
-(#s)=
-
 ## S
-
-(#sprite)=
 
 ### Sprite
 
 - pice of graphic (not necessarily only one `.png` file).
-
-(#t)=
 
 ## T
 
 ### Task
 
 - Represented as an issue on GitHub
-
-(#tile)=
 
 ### Tile
 
@@ -186,25 +129,15 @@ Imagine the phrase: `A xy is ...` when writing an explanation.
 
 - unity palette where you can create configure [tiles](#tile).
 
-(#u)=
-
 ## U
-
-(#unity)=
 
 ### Unity
 
 - game engine we use
 
-(#v)=
-
 ## V
 
-(#w)=
-
 ## W
-
-(#world)=
 
 ### World
 
@@ -213,14 +146,8 @@ Imagine the phrase: `A xy is ...` when writing an explanation.
 - See the concept [here](/protocols/global/2022-06-03-protocol-1.md)
   - big circle is world
 
-(#x)=
-
 ## X
 
-(#y)=
-
 ## Y
-
-(#z)=
 
 ## Z

--- a/dev-manuals/index.rst
+++ b/dev-manuals/index.rst
@@ -70,6 +70,7 @@ Developer Manuals
    :caption: Services
 
    ./services/*/**
+   ./services/integrate-new-minigame
 
 .. toctree::
    :glob:

--- a/dev-manuals/services/overworld/world-loaders.md
+++ b/dev-manuals/services/overworld/world-loaders.md
@@ -7,7 +7,7 @@ By doing that, the amount of data to handle is smaller and that increases the pe
 
 ## How to create a world loader
 
-To add a new part of the world, you need to [create it](create-new-world.md), [move it to the right place](set-up-area.md) and set up the loading and unloading.  
+To add a new part of the world, you need to [create it](create-new-world.md), [move it to the right place](add-area.md) and set up the loading and unloading.  
 To do that, do the following:
 
 1. Open the scene, in which the scene transition should be

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+linkify-it-py==2.0.0
 myst-parser==0.17.2
 Sphinx==4.5.0


### PR DESCRIPTION
This includes
- title anchors that can be used just as in GitHub (i.e. `test#a-title`)
- URL-like strings will now be automatically converted to a link (i.e. `www.google.com` -> `<www.google.com>`)
- we can now display infos, warnings, and several other notifications that were previously impossible using for example
````
```{warning} The title
The content
```
````

Additionally fix some warnings and remove now no longer needed manual anchors.