### PR TITLE
Configure where the configuration can be found

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,5 +7,7 @@ build:
 python:
   install:
     - requirements: requirements.txt
+sphinx:
+  configuration: conf.py
 
 formats: all


### PR DESCRIPTION
Due to recent ReadTheDocs changes, the config path is no longer auto-implied.
Instead, it must be set manually.